### PR TITLE
chore(platform): update stax legal entity name

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ Homebrew taps publised by stax.
 
 # License
 
-Copyright Stax Pty. Ltd.
+Copyright Stax-WMS Pty Ltd.


### PR DESCRIPTION
The license entity name has been changed to Stax-WMS Pty Ltd.