### PR TITLE
fix(platform): 🐛 remove depreciated :unneeded

### DIFF
--- a/stax2aws.rb
+++ b/stax2aws.rb
@@ -6,7 +6,6 @@ class Stax2aws < Formula
   desc "Official CLI for logging into Stax-managed AWS accounts."
   homepage "https://github.com/stax-labs/stax2aws-releases"
   version "1.4.1"
-  bottle :unneeded
 
   on_macos do
     if Hardware::CPU.intel?


### PR DESCRIPTION
Prior to this change, stax2aws homebrew formula tab was using an obsolete argument ":unneeded". This would result in the following error while interacting with `brew`

```
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the stax-labs/taps tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/stax-labs/homebrew-taps/stax2aws.rb:9
```

This change simply removes the argument as there appears to be no replacement. It seems that within homebrew/core bottle :unneeded is a no-op.